### PR TITLE
Bug fix: Board not clearing on starting new game

### DIFF
--- a/assets/javascript/memoryGame.js
+++ b/assets/javascript/memoryGame.js
@@ -50,8 +50,6 @@ function fillBoard() {
     cards.splice(randomCard, 1); // remove the card so that it doesn't get picked again
   }
 
-  console.log("Cards", cards)
-  console.log("Board", board)
 }
 
 function buildBoard() {

--- a/assets/javascript/memoryGame.js
+++ b/assets/javascript/memoryGame.js
@@ -3,7 +3,6 @@
 cards = []; // array to hold up to 8 image files representing 8 memory cards
 board = []; // array to hold 2 X 8 images, randomly organized
 
-
 cardsFlippedArray = []; // array to hold the 2 cards that have been flipped, for comparing.
 
 let cardsFlipped = 0; // number of cards flipped, min = 0, max 2;
@@ -22,9 +21,6 @@ function startNewGame() {
   fillBoard();
   buildBoard();
   // matchCards();
-
-
-
 }
 
 function clearBoardArray() {
@@ -49,7 +45,6 @@ function fillBoard() {
     board.push(cards[randomCard]); // push the card into the board array
     cards.splice(randomCard, 1); // remove the card so that it doesn't get picked again
   }
-
 }
 
 function buildBoard() {
@@ -78,7 +73,6 @@ function buildBoard() {
       row += "</tr>";
     }
   }
-
 
   /* final, display the table on the web page */
   document.getElementById("board").innerHTML = "<table>" + row + "</table>";

--- a/assets/javascript/memoryGame.js
+++ b/assets/javascript/memoryGame.js
@@ -3,6 +3,7 @@
 cards = []; // array to hold up to 8 image files representing 8 memory cards
 board = []; // array to hold 2 X 8 images, randomly organized
 
+
 cardsFlippedArray = []; // array to hold the 2 cards that have been flipped, for comparing.
 
 let cardsFlipped = 0; // number of cards flipped, min = 0, max 2;
@@ -16,10 +17,18 @@ function startNewGame() {
   // clear the board
   document.getElementById("board").innerHTML = "";
 
+  clearBoard()
   fillCardsArray();
   fillBoard();
   buildBoard();
   // matchCards();
+
+
+
+}
+
+function clearBoard() {
+  board = []
 }
 
 function fillCardsArray() {
@@ -40,6 +49,9 @@ function fillBoard() {
     board.push(cards[randomCard]); // push the card into the board array
     cards.splice(randomCard, 1); // remove the card so that it doesn't get picked again
   }
+
+  console.log("Cards", cards)
+  console.log("Board", board)
 }
 
 function buildBoard() {
@@ -68,6 +80,7 @@ function buildBoard() {
       row += "</tr>";
     }
   }
+
 
   /* final, display the table on the web page */
   document.getElementById("board").innerHTML = "<table>" + row + "</table>";

--- a/assets/javascript/memoryGame.js
+++ b/assets/javascript/memoryGame.js
@@ -17,7 +17,7 @@ function startNewGame() {
   // clear the board
   document.getElementById("board").innerHTML = "";
 
-  clearBoard()
+  clearBoardArray()
   fillCardsArray();
   fillBoard();
   buildBoard();
@@ -27,7 +27,7 @@ function startNewGame() {
 
 }
 
-function clearBoard() {
+function clearBoardArray() {
   board = []
 }
 


### PR DESCRIPTION
## The issue:

Everytime the `startNewGame()` function would trigger, the board would populate twice the amount of cards necessary.

## The fix:

Clearing the innerHTML on the start of a new game is necessary, but only one half of the garbage collection process.
The `board` array was still filled with the items from the previous game since the variable itself is created OUTSIDE the scope of any function.

Added a `clearBoard()` function that is triggered immediately on `startNewGame()` that will ensure the `board` array is ALWAYS empty.